### PR TITLE
TLS enabled

### DIFF
--- a/filebeat.yml
+++ b/filebeat.yml
@@ -68,8 +68,8 @@ output:
     hosts: ["LOGSTASH_HOST:LOGSTASH_PORT"]
     index: INDEX
     # Optional TLS. The default is on
-    tls:
-      disabled: true
+    #tls:
+      #disabled: true
 
       # List of root certificates for HTTPS server verifications
       #certificate_authorities: ["/etc/pki/root/ca.pem"]


### PR DESCRIPTION
Removed section tls from config yml due a change in the new version that enables TLS if section is present

https://discuss.elastic.co/t/transport-go-125-err-ssl-client-failed-to-connect-with-eof/35272/2